### PR TITLE
Add an option to disable usage of special characters in the database password

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ backends:  # Configuration for the different backends. Required fields are only 
     pvc_cleanup: false  # If set to true the operator will when deleting a server also delete the persistent volumes, optional
 security: # Security-related settings independent of any backends, optional
   password_length: 16  # Number of characters to use for passwords that are generated for servers and databases, optional
+  special_characters: false # disable usage of special characters (+-_.:<>?) in the password. Defaults to "true"
 ```
 
 Single configuration options can also be provided via environment variables, the complete path is concatenated using underscores, written in uppercase and prefixed with `HYBRIDCLOUD_`. As an example: `backends.azure.subscription_id` becomes `HYBRIDCLOUD_BACKENDS_AZURE_SUBSCRIPTION_ID`.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ backends:  # Configuration for the different backends. Required fields are only 
     pvc_cleanup: false  # If set to true the operator will when deleting a server also delete the persistent volumes, optional
 security: # Security-related settings independent of any backends, optional
   password_length: 16  # Number of characters to use for passwords that are generated for servers and databases, optional
-  special_characters: false # disable usage of special characters (+-_.:<>?) in the password. Defaults to "true"
+  special_characters: true # Allows to enable/disable the usage of special characters (+-_.:<>?) in the passwords. Defaults to true, optional
 ```
 
 Single configuration options can also be provided via environment variables, the complete path is concatenated using underscores, written in uppercase and prefixed with `HYBRIDCLOUD_`. As an example: `backends.azure.subscription_id` becomes `HYBRIDCLOUD_BACKENDS_AZURE_SUBSCRIPTION_ID`.

--- a/hybridcloud/handlers/postgresql_database.py
+++ b/hybridcloud/handlers/postgresql_database.py
@@ -49,7 +49,7 @@ def postgresql_database_manage(spec, meta, labels, name, namespace, body, status
         nonlocal password
         if credentials_secret:
             # Generate a new password
-            password = generate_password(int(config_get("security.password_length", default=16)))
+            password = generate_password(int(config_get("security.password_length", default=16)), bool(config_get("security.special_characters", default=True)))
             k8s.delete_secret(namespace, credentials_secret_name)
             k8s.create_secret(env.OPERATOR_NAMESPACE, tmp_secret_name, {"password": password})
             credentials_secret = None

--- a/hybridcloud/handlers/postgresql_database.py
+++ b/hybridcloud/handlers/postgresql_database.py
@@ -49,7 +49,7 @@ def postgresql_database_manage(spec, meta, labels, name, namespace, body, status
         nonlocal password
         if credentials_secret:
             # Generate a new password
-            password = generate_password(int(config_get("security.password_length", default=16)), bool(config_get("security.special_characters", default=True)))
+            password = generate_password(int(config_get("security.password_length", default=16)), special_chars=config_get("security.special_characters", default=True))
             k8s.delete_secret(namespace, credentials_secret_name)
             k8s.create_secret(env.OPERATOR_NAMESPACE, tmp_secret_name, {"password": password})
             credentials_secret = None

--- a/hybridcloud/handlers/postgresql_server.py
+++ b/hybridcloud/handlers/postgresql_server.py
@@ -46,7 +46,7 @@ def postgresql_server_handler(body, spec, status, meta, labels, name, namespace,
         nonlocal password
         if credentials_secret:
             # Generate a new password
-            password = generate_password(int(config_get("security.password_length", default=16)), bool(config_get("security.special_characters", default=True)))
+            password = generate_password(int(config_get("security.password_length", default=16)), special_chars=config_get("security.special_characters", default=True))
             k8s.delete_secret(namespace, spec["credentialsSecret"])
             k8s.create_or_update_secret(env.OPERATOR_NAMESPACE, tmp_secret_name, {"password": password})
             credentials_secret = None

--- a/hybridcloud/handlers/postgresql_server.py
+++ b/hybridcloud/handlers/postgresql_server.py
@@ -46,7 +46,7 @@ def postgresql_server_handler(body, spec, status, meta, labels, name, namespace,
         nonlocal password
         if credentials_secret:
             # Generate a new password
-            password = generate_password(int(config_get("security.password_length", default=16)))
+            password = generate_password(int(config_get("security.password_length", default=16)), bool(config_get("security.special_characters", default=True)))
             k8s.delete_secret(namespace, spec["credentialsSecret"])
             k8s.create_or_update_secret(env.OPERATOR_NAMESPACE, tmp_secret_name, {"password": password})
             credentials_secret = None

--- a/hybridcloud/util/password.py
+++ b/hybridcloud/util/password.py
@@ -19,7 +19,7 @@ def generate_password(length=16, special_chars=True, must_contain_all=True):
 
 
 def _check_contains(password, special_chars):
-    groups  = [string.ascii_lowercase, string.ascii_uppercase, string.digits]
+    groups = [string.ascii_lowercase, string.ascii_uppercase, string.digits]
     if special_chars:
         groups.append(SPECIAL_CHARACTERS)
     for group in groups:

--- a/hybridcloud/util/reconcile_helpers.py
+++ b/hybridcloud/util/reconcile_helpers.py
@@ -74,7 +74,7 @@ def determine_resource_password(credentials_secret, tmp_secret_name):
     elif tmp_secret:
         password = base64.b64decode(tmp_secret.data["password"]).decode("utf-8")
     else:
-        password = generate_password(int(config_get("security.password_length", default=16)))
+        password = generate_password(int(config_get("security.password_length", default=16)), bool(config_get("security.special_characters", default=True)))
         k8s.create_secret(env.OPERATOR_NAMESPACE, tmp_secret_name, {"password": password})
     return password
 

--- a/hybridcloud/util/reconcile_helpers.py
+++ b/hybridcloud/util/reconcile_helpers.py
@@ -74,7 +74,7 @@ def determine_resource_password(credentials_secret, tmp_secret_name):
     elif tmp_secret:
         password = base64.b64decode(tmp_secret.data["password"]).decode("utf-8")
     else:
-        password = generate_password(int(config_get("security.password_length", default=16)), bool(config_get("security.special_characters", default=True)))
+        password = generate_password(int(config_get("security.password_length", default=16)), special_chars=config_get("security.special_characters", default=True))
         k8s.create_secret(env.OPERATOR_NAMESPACE, tmp_secret_name, {"password": password})
     return password
 


### PR DESCRIPTION
Some clients will struggle with special characters in database passwords and require complicated escaping