### PR TITLE
Add parameters "extraLabels" and "extraLabelsSelector"

### DIFF
--- a/helm/hybrid-cloud-postgresql-operator/templates/_helpers.tpl
+++ b/helm/hybrid-cloud-postgresql-operator/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "operator.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.extraLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -48,6 +51,9 @@ Selector labels
 {{- define "operator.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- range $key, $value := .Values.extraLabelsSelector }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/hybrid-cloud-postgresql-operator/values.yaml
+++ b/helm/hybrid-cloud-postgresql-operator/values.yaml
@@ -34,6 +34,15 @@ envSecret: null
 # A list of environment variables (with name, value) to provide to the operator
 extraEnv: []
 
+# provide users with the option to add additional common labels to the deployment
+# NOTE that all additional selector labels from `extraLabelsSelector` are already included in the "common" labels
+# and can not be added twice
+extraLabels: {}
+# provide users with the option to add additional selector labels to deployment and its pods
+# NOTE that selector labels are immutable once the deployment was created
+# so adding new ones requires deleting the deployment first
+extraLabelsSelector: {}
+
 # List of volumes to mount into the operator pod
 volumes: []
 # List of volume mounts for the operator pod


### PR DESCRIPTION
 to allow users to specify their own set of labels for the deployment and pods

In some enviornments it might be a requirement that all pods from a certain team, have the label `team: penguins`
This enables such a configuration for the operator pod